### PR TITLE
Formatted team ranking print to be tabular.

### DIFF
--- a/baseballPageRankv2.py
+++ b/baseballPageRankv2.py
@@ -207,7 +207,7 @@ ranking, teams = pageRank(df, damping, postSeason)
 numTeams = len(teams)
 print("\n\n")
 for i in range(numTeams):
-    print(teams[i]+":    "+str(ranking[i]))
+    print(str(i).rjust(2) + " | " + teams[i].ljust(21) + " | " + str(round(ranking[i], 3)).ljust(6, "0"))
 
 
 print("\n\n")


### PR DESCRIPTION
# CONTEXT:
The team ranking print is unformatted, which makes it difficult to read. For example (2023 season):
```
Atlanta Braves:    100.00000000000001
Baltimore Orioles:    96.17877051923202
Los Angeles Dodgers:    95.29215468298275
Tampa Bay Rays:    94.00003636283489
Philadelphia Phillies:    91.72738953542058
Milwaukee Brewers:    89.19201795251445
Texas Rangers:    88.23849002208512
Toronto Blue Jays:    87.24376294201747
Houston Astros:    87.15606039727174
Arizona D'Backs:    84.50944483584765
New York Yankees:    84.32583129905439
Miami Marlins:    82.87279500527629
San Diego Padres:    81.92782353701539
Chicago Cubs:    81.66382302655506
Cincinnati Reds:    81.64713383732172
Boston Red Sox:    81.60283984926036
Minnesota Twins:    81.53754388861515
Seattle Mariners:    80.39263415517006
San Francisco Giants:    80.38990641002202
New York Mets:    77.5107636944057
Pittsburgh Pirates:    76.31419626840515
Cleveland Guardians:    75.14738076780714
St. Louis Cardinals:    74.45746821386035
Washington Nationals:    73.8142264457234
Detroit Tigers:    72.00606798947884
Los Angeles Angels:    71.49741329807372
Colorado Rockies:    62.104380431093126
Chicago White Sox:    62.01989817309798
Kansas City Royals:    58.47327863404495
Oakland Athletics:    53.86178854293818
```

# CHANGE:
- Formatted the team ranking print to be tabular. For example (2023 season):
```
 0 | Atlanta Braves        | 100.00
 1 | Baltimore Orioles     | 96.179
 2 | Los Angeles Dodgers   | 95.292
 3 | Tampa Bay Rays        | 94.000
 4 | Philadelphia Phillies | 91.727
 5 | Milwaukee Brewers     | 89.192
 6 | Texas Rangers         | 88.238
 7 | Toronto Blue Jays     | 87.244
 8 | Houston Astros        | 87.156
 9 | Arizona D'Backs       | 84.509
10 | New York Yankees      | 84.326
11 | Miami Marlins         | 82.873
12 | San Diego Padres      | 81.928
13 | Chicago Cubs          | 81.664
14 | Cincinnati Reds       | 81.647
15 | Boston Red Sox        | 81.603
16 | Minnesota Twins       | 81.538
17 | Seattle Mariners      | 80.393
18 | San Francisco Giants  | 80.390
19 | New York Mets         | 77.511
20 | Pittsburgh Pirates    | 76.314
21 | Cleveland Guardians   | 75.147
22 | St. Louis Cardinals   | 74.457
23 | Washington Nationals  | 73.814
24 | Detroit Tigers        | 72.006
25 | Los Angeles Angels    | 71.497
26 | Colorado Rockies      | 62.104
27 | Chicago White Sox     | 62.020
28 | Kansas City Royals    | 58.473
29 | Oakland Athletics     | 53.862
```